### PR TITLE
Use single global random device

### DIFF
--- a/src/main/sim/simulation.cpp
+++ b/src/main/sim/simulation.cpp
@@ -1,7 +1,3 @@
 #include "simulation.h"
 
-
-namespace vol {
-
-}
-
+std::random_device vol::generator::rd = std::random_device{};

--- a/src/main/sim/simulation.h
+++ b/src/main/sim/simulation.h
@@ -6,8 +6,11 @@
 
 namespace vol {  
   
+
   namespace generator {
     
+    extern std::random_device rd; // storage is assigned in cpp file.
+
     template<typename gen_type, typename dist_type>
     auto create(dist_type&& adapter, std::seed_seq& seeds) {
       gen_type gen;
@@ -17,7 +20,6 @@ namespace vol {
 
     template<typename gen_type, typename dist_type>
     auto create(dist_type&& adapter) {
-      std::random_device rd{};
       gen_type gen(rd());
       return [adapter, gen]() mutable { return adapter(gen);};
     }


### PR DESCRIPTION
Not sure how useful this is, I'm not sure that there are tests to address:

"
so I have a have an rng wrapped in a lambda instance.  The lambda instance address is constant and the encapsulation of the rng seems perfect (the address of the rng object is also constant and there is no program access to its state),  but at the end of each path, the state of the rng resets.
"